### PR TITLE
Allow Models with PKs other than `id`

### DIFF
--- a/src/Traits/HasEmbeddings.php
+++ b/src/Traits/HasEmbeddings.php
@@ -24,7 +24,7 @@ trait HasEmbeddings
         foreach ($embeddings as $embedding) {
             $embedding->key = $key;
             $embedding->embeddable_type = static::class;
-            $embedding->embeddable_id = $this->id;
+            $embedding->embeddable_id = $this->getKey();
 
             $embedding->save();
 

--- a/src/Traits/HasEmbeddings.php
+++ b/src/Traits/HasEmbeddings.php
@@ -6,6 +6,9 @@ use Ada\Index\Index;
 use Ada\Jobs\EmbedJob;
 use Ada\Models\Embedding;
 
+/**
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
 trait HasEmbeddings
 {
     public function embed(string $key, string $content): bool


### PR DESCRIPTION
Hello my 🥨 friend,

this PR adds the ability to have a model with a uuid as primary key by using laravel's `getKey` helper.
in addition a added the `@mixin` to the trait to fix autocompletion.

Cheers Adrian